### PR TITLE
Accept new values from mutate_json_record

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ ISO8601 date mutation.
         json_lib = ujson
 
         def mutate_json_record(self, json_record):
-            pass
+            return json_record
 
 Tests
 -----

--- a/json_log_formatter/__init__.py
+++ b/json_log_formatter/__init__.py
@@ -61,8 +61,13 @@ class JSONFormatter(logging.Formatter):
         message = record.getMessage()
         extra = self.extra_from_record(record)
         json_record = self.json_record(message, extra, record)
-        self.mutate_json_record(json_record)
-        return self.json_lib.dumps(json_record)
+        mutated_record = self.mutate_json_record(json_record)
+        # Backwards compatibility: Functions that overwrite this but don't
+        # return a new value will return None because they modified the
+        # argument passed in.
+        if mutated_record is None:
+            mutated_record = json_record
+        return self.json_lib.dumps(mutated_record)
 
     def extra_from_record(self, record):
         """Returns `extra` dict you passed to logger.
@@ -104,3 +109,4 @@ class JSONFormatter(logging.Formatter):
             attr = json_record[attr_name]
             if isinstance(attr, datetime):
                 json_record[attr_name] = attr.isoformat()
+        return json_record

--- a/tests.py
+++ b/tests.py
@@ -65,6 +65,27 @@ class JSONFormatterTest(TestCase):
         self.assertEqual(set(json_record), expected_fields)
 
 
+class MutatingFormatter(JSONFormatter):
+
+    def mutate_json_record(self, json_record):
+        new_record = {}
+        for k, v in json_record.items():
+            if isinstance(v, datetime):
+                v = v.isoformat()
+            new_record[k] = v
+        return new_record
+
+
+class MutatingFormatterTest(TestCase):
+    def setUp(self):
+        json_handler.setFormatter(MutatingFormatter())
+
+    def test_new_record_accepted(self):
+        logger.info('Sign up', extra={'fizz': DATETIME})
+        json_record = json.loads(log_buffer.getvalue())
+        self.assertEqual(json_record['fizz'], DATETIME_ISO)
+
+
 class JsonLibTest(TestCase):
     def setUp(self):
         json_handler.setFormatter(JSONFormatter())


### PR DESCRIPTION
The current implementation modifies an argument which is not always good. The
assumption that the extra argument is not re-used by the callee is reasonable
but ultimately cannot be relied on all the time. This change gives implementers
the change to catch an extra dict that contains references to re-used objects
and replace them with their own objects. The current implementation will not
take care of that for them but enables the creation of such a function.

We also retain backwards compatibility by using the modified argument if no
return value was provided.
