### PR TITLE
JSON-serialize WSGIRequest

### DIFF
--- a/json_log_formatter/__init__.py
+++ b/json_log_formatter/__init__.py
@@ -122,4 +122,7 @@ class JSONFormatter(logging.Formatter):
             attr = json_record[attr_name]
             if isinstance(attr, datetime):
                 json_record[attr_name] = attr.isoformat()
+            # django.core.handlers.wsgi.WSGIRequest
+            elif attr.__class__.__name__ == "WSGIRequest":
+                json_record[attr_name] = "{} {}".format(attr.method, attr.path)
         return json_record


### PR DESCRIPTION
In Django, when executing the code of a view that raises an exception and having a json formatter configured to handle `django.request` logs, the json log line cannot be serialized because it includes an instance of WSGIRequest, which is not JSON-serializable.

It is the `request` variable at https://github.com/django/django/blob/50cf183d219face91822c75fa0a15fe2fe3cb32d/django/utils/log.py#L222-L229