### PR TITLE
Make best effort to serialize json, e.g., WSGIRequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.7
   - 3.8
 install:
-  - pip install ujson simplejson
+  - pip install ujson simplejson django
   - python setup.py install
 script: nosetests tests
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ JSON libraries
 --------------
 
 You can use **ujson** or **simplejson** instead of built-in **json** library.
-They are faster and can serialize ``Decimal`` values.
 
 .. code-block:: python
 
@@ -60,6 +59,9 @@ They are faster and can serialize ``Decimal`` values.
 
     formatter = json_log_formatter.JSONFormatter()
     formatter.json_lib = ujson
+
+Note, **ujson** doesn't support `dumps(default=f)` argument:
+if it can't serialize an attribute, it might fail with `TypeError` or skip an attribute.
 
 Django integration
 ------------------
@@ -111,7 +113,7 @@ To do so you should override ``JSONFormatter.json_record()``.
             return extra
 
 Let's say you want ``datetime`` to be serialized as timestamp.
-Then you should use **ujson** (which does it by default) and disable
+You can use **ujson** (which does it by default) and disable
 ISO8601 date mutation.
 
 .. code-block:: python

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ deps=
     pytest
     ujson
     simplejson
+    django
 commands=
     pytest -s tests.py


### PR DESCRIPTION
By default the library should try to serialize a log record instead of raising an exception as suggested in https://github.com/marselester/json-log-formatter/pull/12.