### PR TITLE
Deprecate Python versions below 3.6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Marsel Mavletkulov
+Copyright (c) 2024 Marsel Mavletkulov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/json_log_formatter/__init__.py
+++ b/json_log_formatter/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 import json
 
@@ -120,7 +120,7 @@ class JSONFormatter(logging.Formatter):
         """
         extra['message'] = message
         if 'time' not in extra:
-            extra['time'] = datetime.utcnow()
+            extra['time'] = datetime.now(timezone.utc)
 
         if record.exc_info:
             extra['exc_info'] = self.formatException(record.exc_info)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,20 +7,19 @@ packages = ["json_log_formatter"]
 
 [project]
 name = "JSON-log-formatter"
-version = "0.5.2"
+version = "1.0"
 description = "JSON log formatter"
 readme = "README.rst"
-requires-python = ">=2.7"
+requires-python = ">=3.6"
 license = {text = "MIT"}
 authors = [
-    {name = "Marsel Mavletkulov", email = "marselester@ya.ru"},
+    {name = "Marsel Mavletkulov"},
 ]
 classifiers=[
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@ from setuptools import setup
 
 setup(
     name='JSON-log-formatter',
-    version='0.5.2',
+    version='1.0',
     license='MIT',
     packages=['json_log_formatter'],
     author='Marsel Mavletkulov',
-    author_email='marselester@ya.ru',
     url='https://github.com/marselester/json-log-formatter',
     description='JSON log formatter',
     long_description=open('README.rst').read(),
@@ -15,7 +14,6 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist=py27,py35,py36,py37,py38,py39,py310,py311,py312
+envlist=py36,py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps=
     pytest
-    ujson==5.9.0
-    simplejson==3.19.2
+    ujson
+    simplejson
     django
 commands=
     pytest -s tests.py


### PR DESCRIPTION
See https://github.com/marselester/json-log-formatter/issues/32.