### PR TITLE
Add taskName to BUILTIN_ATTRS set

### DIFF
--- a/json_log_formatter/__init__.py
+++ b/json_log_formatter/__init__.py
@@ -25,6 +25,7 @@ BUILTIN_ATTRS = {
     'processName',
     'relativeCreated',
     'stack_info',
+    'taskName',
     'thread',
     'threadName',
 }


### PR DESCRIPTION
`taskName` is a new attribute of `LogRecord`, that was added in Python 3.12. See the [doc](https://docs.python.org/3/library/logging.html#logrecord-attributes)