### PR TITLE
build and publish wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ test:
 	tox
 
 pypi:
-	python setup.py sdist
+	python -m build
 	python -m twine upload dist/*


### PR DESCRIPTION
Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish a wheel.

I did not find where you set up the environment for such things, you will need to `pip install build` (just as currently you must `pip install twine`).